### PR TITLE
Feat: Wiki 기타 기능 추가

### DIFF
--- a/src/components/Wiki/WikiDefaultPage.tsx
+++ b/src/components/Wiki/WikiDefaultPage.tsx
@@ -10,26 +10,41 @@ const WikiDefaultPage = () => {
       <h1>📘 위키 가이드</h1>
 
       <StyledDiv>
+        <WikiIcon />
         <StyledText>
           <div>
-            <h3>폴더 기능 정리</h3>
-            <ul>
-              <li>새 폴더 추가 버튼을 눌러...</li>
-              <li>점 아이콘을 클릭해 폴더명을 변경해...</li>
-              <li>점 아이콘을 클릭해 폴더를 삭제해</li>
-            </ul>
+            <h2>폴더 및 파일 관리</h2>
+            <p>
+              새 폴더를 추가하려면 &quot;새 폴더 추가&quot; 버튼을 클릭하세요.
+              폴더는 날짜순으로 정렬됩니다.
+            </p>
+            <p>
+              생성된 폴더의 오른쪽 메뉴를 클릭하여 폴더의 이름을 변경하거나
+              폴더를 삭제할 수 있습니다.
+            </p>
+            <p>
+              마찬가지로 폴더의 오른쪽 메뉴에서 새로운 파일을 생성할 수
+              있습니다.
+            </p>
+            <p>
+              새로운 파일을 클릭하면 에디터로 이동하고, 에디터에서 마크다운
+              형식으로 글을 작성한 후 &quot;등록&quot; 버튼을 누르면 글 생성이
+              완료됩니다.
+            </p>
+            <p>
+              파일에서는 &quot;수정&quot; 버튼과 &quot;삭제&quot; 버튼을 통해
+              글을 수정하거나 삭제할 수 있습니다.
+            </p>
           </div>
           <div>
-            <h3>파일 기능 정리</h3>
-            <ul>
-              <li>점 아이콘을 클릭해 새로운 파일을 생성해...</li>
-              <li>파일에서 파일 제목을 변경...</li>
-              <li>파일에서 파일 내용을 수정...</li>
-              <li>파일에서 파일을 삭제...</li>
-            </ul>
+            <h2>폴더 순서 변경</h2>
+            <p>
+              이미 정렬된 폴더의 순서를 변경하려면 메뉴에서 폴더를 드래그하여
+              순서를 바꿀 수 있습니다.
+            </p>
+            <p>아쉽게도 파일의 순서는 날짜순 외에는 정렬할 수 없습니다.</p>
           </div>
         </StyledText>
-        <Wiki />
       </StyledDiv>
     </Container>
   );
@@ -42,22 +57,30 @@ const Container = styled.div`
   padding: 0;
   margin-left: 10px;
   h1 {
-    width: 185px;
     font-size: 2rem;
   }
 `;
+
 const StyledDiv = styled.div`
+  margin-top: 80px;
   display: flex;
-  justify-content: flex-start;
   align-items: flex-start;
+  gap: 20px;
 `;
+
+const WikiIcon = styled(Wiki)`
+  width: 33%;
+`;
+
 const StyledText = styled.div`
-  margin-top: 20px;
-  margin-left: 5px;
-  margin-right: 100px;
+  width: 67%;
+  margin-left: 20px;
   div {
-    h3 {
+    h2 {
       font-size: 1.5rem;
+    }
+    p {
+      margin-bottom: 10px;
     }
   }
 `;

--- a/src/components/Wiki/WikiEditor.tsx
+++ b/src/components/Wiki/WikiEditor.tsx
@@ -26,12 +26,13 @@ import {
   where,
   getDocs,
   updateDoc,
+  Timestamp,
 } from "firebase/firestore";
 import { storage } from "../../libs/firebase";
 import { getDownloadURL, ref, uploadBytes } from "firebase/storage";
 
 // Interface
-import { IItems } from "../../store/wiki";
+import { IItem } from "../Wiki/WikiSubPage";
 
 const WikiEditor = () => {
   const editorRef = useRef<ToastUIEditor | null>(null);
@@ -52,11 +53,13 @@ const WikiEditor = () => {
     const FolderDoc = querySnapshot.docs[0];
     const items = FolderDoc.data().items;
     const itemIndex = items.findIndex(
-      (item: IItems) => item.name === currentFile,
+      (item: IItem) => item.name === currentFile,
     );
 
     if (itemIndex !== -1) {
       items[itemIndex].subName = newData;
+      const timeStamp = Timestamp.now();
+      items[itemIndex].date = timeStamp;
       const data = {
         items: items,
       };
@@ -76,7 +79,6 @@ const WikiEditor = () => {
     } else {
       const newData = editorRef.current?.getInstance().getMarkdown();
       if (newData !== undefined) {
-        console.log(3.1);
         postText(newData);
         setEditFile(false);
       }
@@ -86,10 +88,6 @@ const WikiEditor = () => {
   useEffect(() => {
     console.log("Wiki Editor 등록 완료");
   }, [item]);
-
-  useEffect(() => {
-    console.log(1);
-  }, []);
 
   const onUploadImage = async (
     blob: Blob | File,

--- a/src/components/Wiki/WikiNav.tsx
+++ b/src/components/Wiki/WikiNav.tsx
@@ -118,6 +118,7 @@ const WikiNav = () => {
     e.preventDefault();
     addFolder(newFolder, refreshFolders);
     setInputState(false);
+    setNewFolder("");
   };
 
   const onChangeFolder = (e: ChangeEvent<HTMLInputElement>) => {

--- a/src/components/Wiki/WikiNav.tsx
+++ b/src/components/Wiki/WikiNav.tsx
@@ -9,6 +9,8 @@ import {
   FolderOutlined,
   FileOutlined,
   FolderAddOutlined,
+  TeamOutlined,
+  LockOutlined,
 } from "@ant-design/icons";
 import { Input } from "antd";
 
@@ -198,111 +200,121 @@ const WikiNav = () => {
     <DragDropContext onDragEnd={handleDragEnd}>
       <Droppable droppableId="folders">
         {(provided) => (
-          <StyledContainer>
-            <StyledDiv>
-              <StyledForm
-                onClick={() => {
-                  setInputState((prev) => !prev);
-                }}
-              >
-                <FolderAddOutlined
-                  style={{ color: "white", fontSize: "15px" }}
-                />
-                <FormSpan>새 폴더 추가</FormSpan>
-              </StyledForm>
-              {inputState && (
-                <NewFolderContainer>
-                  <form onSubmit={onSubmitFolder}>
-                    <Input
-                      placeholder="새 폴더명을 입력해주세요"
-                      value={newFolder}
-                      onChange={onChangeFolder}
-                      style={{
-                        padding: "6.5px",
-                        borderRadius: "0",
-                        border: "none",
-                        borderBottom: "1px solid rgba(0,0,0,0.1)",
-                        paddingLeft: "25px",
-                      }}
-                    />
-                  </form>
-                </NewFolderContainer>
-              )}
-            </StyledDiv>
-            <StyledUl {...provided.droppableProps} ref={provided.innerRef}>
-              {items.map((item, index: number) => (
-                <Draggable
-                  key={item.title}
-                  draggableId={item.title + index}
-                  index={index}
+          <Container>
+            <StyledContainer>
+              <FolderWrapper>
+                <TeamOutlined />
+                <StyledFolderTitle>전체</StyledFolderTitle>
+              </FolderWrapper>
+              <StyledDiv>
+                <StyledForm
+                  onClick={() => {
+                    setInputState((prev) => !prev);
+                  }}
                 >
-                  {(provided) => (
-                    <ItemContainer key={item.title + index}>
-                      <li
-                        ref={provided.innerRef}
-                        {...provided.draggableProps}
-                        {...provided.dragHandleProps}
-                        onClick={() => handleLiClick(item.title)}
-                      >
-                        <StyledTitle>
-                          <div>
-                            {(folderState && currentFolder) === item.title ? (
-                              <form onSubmit={onSubmitFolderName}>
-                                <Input
-                                  defaultValue={item.title}
-                                  onChange={onChangeFolderName}
-                                  onClick={(e) => e.stopPropagation()}
-                                />
-                              </form>
-                            ) : (
-                              <>
-                                <FolderOutlined />
-                                <StyledSpan>{item.title}</StyledSpan>
-                              </>
+                  <FolderAddOutlined
+                    style={{ color: "white", fontSize: "15px" }}
+                  />
+                  <FormSpan>새 폴더 추가</FormSpan>
+                </StyledForm>
+                {inputState && (
+                  <NewFolderContainer>
+                    <form onSubmit={onSubmitFolder}>
+                      <Input
+                        placeholder="새 폴더명을 입력해주세요"
+                        value={newFolder}
+                        onChange={onChangeFolder}
+                        style={{
+                          padding: "6.5px",
+                          borderRadius: "0",
+                          border: "none",
+                          borderBottom: "1px solid rgba(0,0,0,0.1)",
+                          paddingLeft: "25px",
+                        }}
+                      />
+                    </form>
+                  </NewFolderContainer>
+                )}
+              </StyledDiv>
+              <StyledUl {...provided.droppableProps} ref={provided.innerRef}>
+                {items.map((item, index: number) => (
+                  <Draggable
+                    key={item.title}
+                    draggableId={item.title + index}
+                    index={index}
+                  >
+                    {(provided) => (
+                      <ItemContainer key={item.title + index}>
+                        <li
+                          ref={provided.innerRef}
+                          {...provided.draggableProps}
+                          {...provided.dragHandleProps}
+                          onClick={() => handleLiClick(item.title)}
+                        >
+                          <StyledTitle>
+                            <div>
+                              {(folderState && currentFolder) === item.title ? (
+                                <form onSubmit={onSubmitFolderName}>
+                                  <Input
+                                    defaultValue={item.title}
+                                    onChange={onChangeFolderName}
+                                    onClick={(e) => e.stopPropagation()}
+                                  />
+                                </form>
+                              ) : (
+                                <>
+                                  <FolderOutlined />
+                                  <StyledSpan>{item.title}</StyledSpan>
+                                </>
+                              )}
+                            </div>
+                            <div
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleWikiSelectToggle(e);
+                              }}
+                            >
+                              <WikiSelect title={item.title} />
+                            </div>
+                          </StyledTitle>
+                          <StyledFile isopen={item.title === currentFolder}>
+                            {fileState && (
+                              <FormContainer>
+                                <FileOutlined style={{ fontSize: "14px" }} />
+                                <FileForm onSubmit={onSubmitFile}>
+                                  <Input
+                                    placeholder="새로운 파일"
+                                    onChange={onChangeFile}
+                                  />
+                                </FileForm>
+                              </FormContainer>
                             )}
-                          </div>
-                          <div
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              handleWikiSelectToggle(e);
-                            }}
-                          >
-                            <WikiSelect title={item.title} />
-                          </div>
-                        </StyledTitle>
-                        <StyledFile isopen={item.title === currentFolder}>
-                          {fileState && (
-                            <FormContainer>
-                              <FileOutlined style={{ fontSize: "14px" }} />
-                              <FileForm onSubmit={onSubmitFile}>
-                                <Input
-                                  placeholder="새로운 파일"
-                                  onChange={onChangeFile}
-                                />
-                              </FileForm>
-                            </FormContainer>
-                          )}
-                          {item.items &&
-                            item.items.map((v, fileIndex: number) => (
-                              <StyledItem
-                                key={v.name + fileIndex}
-                                onClick={() => handleFileClick(v.name)}
-                              >
-                                <div>
-                                  <FileOutlined />
-                                  <StyledSpan>{v.name}</StyledSpan>
-                                </div>
-                              </StyledItem>
-                            ))}
-                        </StyledFile>
-                      </li>
-                    </ItemContainer>
-                  )}
-                </Draggable>
-              ))}
-              {provided.placeholder}
-            </StyledUl>
-          </StyledContainer>
+                            {item.items &&
+                              item.items.map((v, fileIndex: number) => (
+                                <StyledItem
+                                  key={v.name + fileIndex}
+                                  onClick={() => handleFileClick(v.name)}
+                                >
+                                  <div>
+                                    <FileOutlined />
+                                    <StyledSpan>{v.name}</StyledSpan>
+                                  </div>
+                                </StyledItem>
+                              ))}
+                          </StyledFile>
+                        </li>
+                      </ItemContainer>
+                    )}
+                  </Draggable>
+                ))}
+                {provided.placeholder}
+              </StyledUl>
+            </StyledContainer>
+            <FolderWrapper>
+              <LockOutlined />
+              <StyledFolderTitle>팀</StyledFolderTitle>
+            </FolderWrapper>
+          </Container>
         )}
       </Droppable>
     </DragDropContext>
@@ -311,13 +323,36 @@ const WikiNav = () => {
 
 export default WikiNav;
 
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
 const StyledContainer = styled.div`
   margin: 0;
   padding: 0;
   margin-right: 30px;
+  margin-bottom: 30px;
   width: 280px;
   background-color: rgba(0, 0, 0, 0.01);
   border-right: 0.1px solid rgba(0, 0, 0, 0.1);
+`;
+
+const FolderWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  margin-left: 10px;
+  margin-top: 3px;
+  margin-bottom: 8px;
+  color: black;
+  opacity: 0.7;
+  padding-bottom: 5px;
+`;
+
+const StyledFolderTitle = styled.div`
+  font-size: 13px;
+  font-weight: 900;
+  padding-left: 5px;
 `;
 
 const StyledDiv = styled.div`

--- a/src/components/Wiki/WikiSelect.tsx
+++ b/src/components/Wiki/WikiSelect.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useRef } from "react";
 
 // Style
 import styled from "styled-components";
@@ -11,6 +11,7 @@ import {
   editFolderState,
   deleteFolderState,
   SelectProps,
+  SelectState,
 } from "../../store/wiki";
 
 // api
@@ -24,20 +25,41 @@ interface IProps {
   title: string;
 }
 
-function WikiSelect({ title }: IProps) {
+const WikiSelect = ({ title }: IProps) => {
   const [isMenuVisible, setMenuVisible] = useState(false);
   const setFileState = useSetRecoilState(newFileState);
   const setFolderState = useSetRecoilState(editFolderState);
   const setDeleteFolderState = useSetRecoilState(deleteFolderState);
   const setCurrentFolder = useSetRecoilState(SelectProps);
+  const setSelectState = useSetRecoilState(SelectState);
+  const menuRef = useRef(null);
 
   const handleButtonClick = () => {
     setMenuVisible(!isMenuVisible);
   };
 
-  const handleItemClick = (item: string) => {
+  const handleItemClick = () => {
     setMenuVisible(false);
   };
+
+  const handleOutsideClick = () => {
+    if (menuRef.current) {
+      setMenuVisible(false);
+      setSelectState(false);
+    }
+  };
+
+  useEffect(() => {
+    if (isMenuVisible) {
+      document.addEventListener("click", handleOutsideClick);
+    } else {
+      document.removeEventListener("click", handleOutsideClick);
+    }
+
+    return () => {
+      document.removeEventListener("click", handleOutsideClick);
+    };
+  }, [isMenuVisible]);
 
   useEffect(() => {
     console.log("Initialize");
@@ -46,10 +68,10 @@ function WikiSelect({ title }: IProps) {
   return (
     <Container>
       <EllipsisOutlined onClick={handleButtonClick} />
-      <CustomSelectMenu visible={isMenuVisible}>
+      <CustomSelectMenu ref={menuRef} visible={isMenuVisible}>
         <CustomSelectItem
           onClick={() => {
-            handleItemClick(title);
+            handleItemClick();
             setCurrentFolder(title);
             setFolderState((prev) => !prev);
             setCurrentFolder(title);
@@ -59,7 +81,7 @@ function WikiSelect({ title }: IProps) {
         </CustomSelectItem>
         <CustomSelectItem
           onClick={() => {
-            handleItemClick(title);
+            handleItemClick();
             setDeleteFolderState(true);
             deleteFolder(title, setDeleteFolderState);
           }}
@@ -68,7 +90,7 @@ function WikiSelect({ title }: IProps) {
         </CustomSelectItem>
         <CustomSelectItem
           onClick={() => {
-            handleItemClick(title);
+            handleItemClick();
             setFileState((prev) => !prev);
             setCurrentFolder(title);
           }}
@@ -78,7 +100,7 @@ function WikiSelect({ title }: IProps) {
       </CustomSelectMenu>
     </Container>
   );
-}
+};
 
 export default WikiSelect;
 

--- a/src/components/Wiki/WikiSubPage.tsx
+++ b/src/components/Wiki/WikiSubPage.tsx
@@ -20,11 +20,18 @@ import { IWiki } from "../../store/wiki";
 
 // Firebase
 import { db } from "../../libs/firebase";
-import { collection, query, where, getDocs } from "firebase/firestore";
+import {
+  collection,
+  query,
+  where,
+  getDocs,
+  Timestamp,
+} from "firebase/firestore";
 
 export interface IItem {
   name: string;
   subName: string;
+  date?: Timestamp;
 }
 
 const SubPage = () => {
@@ -40,8 +47,6 @@ const SubPage = () => {
     const querySnapshot = await getDocs(q);
     const FolderDoc = querySnapshot.docs[0];
     if (FolderDoc === undefined) {
-      // 초기화면에서 전역값이 null이여서 에러 발생
-      // 기본값 Fix 필요
       const q = query(collection(db, "WikiPage"));
       const querySnapshot = await getDocs(q);
       querySnapshot.docs.map((doc) => doc.data() as IWiki);

--- a/src/components/Wiki/WikiViewer.tsx
+++ b/src/components/Wiki/WikiViewer.tsx
@@ -49,7 +49,7 @@ interface IContent {
 }
 
 const WikiViewer = ({ content }: IContent) => {
-  const { name, subName } = content;
+  const { name, subName, date } = content;
 
   const prevSubNameRef = useRef<string | null>(null);
   const prevNameRef = useRef<string | null>(null);
@@ -57,10 +57,12 @@ const WikiViewer = ({ content }: IContent) => {
   const [renderKey, setRenderKey] = useState(0);
   const [editState, setEditState] = useState<boolean>(false);
   const [editTitle, setEditTitle] = useState<string>(name);
+  const [formattedDate, setFormattedDate] = useState<string | null>(null);
 
   const [currentFile, setCurrentFile] = useRecoilState(currentFileTitle);
   const [editFile, setEditFile] = useRecoilState(editFileState);
   const currentFolder = useRecoilValue(currentFolderTitle);
+
   const setItem = useSetRecoilState(currentItem);
   const setItems = useSetRecoilState(totalItems);
   const setExistSub = useSetRecoilState(editFileSubName);
@@ -164,8 +166,17 @@ const WikiViewer = ({ content }: IContent) => {
   }, [editFile, editFileState]);
 
   useEffect(() => {
-    console.log("Initialize");
-  }, []);
+    if (date) {
+      const year = date.toDate().getFullYear();
+      const month = date.toDate().getMonth() + 1;
+      const day = date.toDate().getDate();
+      const hours = date.toDate().getHours();
+      const minutes = date.toDate().getMinutes();
+
+      const formatDate = `${year}년 ${month}월 ${day}일 ${hours}시 ${minutes}분`;
+      setFormattedDate(formatDate);
+    }
+  }, [date]);
 
   return (
     <Container>
@@ -195,6 +206,7 @@ const WikiViewer = ({ content }: IContent) => {
               <Button onClick={postDelete}>삭제</Button>
             </Space>
           </StyledDiv>
+          <StyledDate>최종 수정일 : {formattedDate}</StyledDate>
           <StyledViewer>
             <Viewer key={renderKey} initialValue={subName} />
           </StyledViewer>
@@ -222,9 +234,16 @@ const StyledDiv = styled.div`
     }
   }
   form {
-    margin: 5px;
+    margin-top: 10px;
+    margin-bottom: 20px;
   }
 `;
 const StyledViewer = styled.div`
   font-size: 1rem !important;
+`;
+const StyledDate = styled.div`
+  opacity: 0.5;
+  font-size: 0.75rem;
+  margin-top: -10px;
+  margin-bottom: 30px;
 `;

--- a/src/hooks/Wiki/api.ts
+++ b/src/hooks/Wiki/api.ts
@@ -23,10 +23,17 @@ export const addFolder = async (
   refreshFc: RefreshFunction,
 ): Promise<void> => {
   if (folderName.length > 0) {
+    const foldersRef = collection(db, "WikiPage");
+    const foldersQuery = query(foldersRef);
+    const foldersQuerySnapshot = await getDocs(foldersQuery);
+    const order = foldersQuerySnapshot.size;
+
     await addDoc(collection(db, "WikiPage"), {
       title: folderName,
       items: [],
+      order: order,
     });
+
     refreshFc();
   }
 };
@@ -75,7 +82,14 @@ export const addFile = async (
       subName: state.subName,
       date: date,
     };
-    exist.push(newFileData);
+
+    const order = exist.length;
+
+    exist.push({
+      ...newFileData,
+      order: order,
+    });
+
     await updateDoc(folderDoc.ref, {
       items: exist,
     });

--- a/src/hooks/Wiki/api.ts
+++ b/src/hooks/Wiki/api.ts
@@ -26,15 +26,25 @@ export const addFolder = async (
     const foldersRef = collection(db, "WikiPage");
     const foldersQuery = query(foldersRef);
     const foldersQuerySnapshot = await getDocs(foldersQuery);
-    const order = foldersQuerySnapshot.size;
+    const existFolderNames: string[] = [];
 
-    await addDoc(collection(db, "WikiPage"), {
-      title: folderName,
-      items: [],
-      order: order,
-    });
+    foldersQuerySnapshot.forEach((doc) =>
+      existFolderNames.push(doc.data().title),
+    );
 
-    refreshFc();
+    if (existFolderNames.includes(folderName)) {
+      alert("이미 같은 이름의 폴더가 존재합니다.");
+    } else {
+      const order = foldersQuerySnapshot.size;
+
+      await addDoc(collection(db, "WikiPage"), {
+        title: folderName,
+        items: [],
+        order: order,
+      });
+
+      refreshFc();
+    }
   }
 };
 

--- a/src/store/wiki.ts
+++ b/src/store/wiki.ts
@@ -1,8 +1,17 @@
 import { atom } from "recoil";
 
+import { Timestamp } from "firebase/firestore";
+
+export interface IWikiItem {
+  name: string;
+  subName: string;
+  date: Timestamp;
+}
+
 export interface IWiki {
   title: string;
-  items: Array<{ name: string; subName: string }>;
+  order: number;
+  items: IWikiItem[];
 }
 
 // 현재 선택한 폴더명
@@ -33,7 +42,8 @@ export const totalItems = atom<IWiki[]>({
   default: [
     {
       title: "",
-      items: [{ name: "", subName: "" }],
+      order: 0,
+      items: [{ name: "", subName: "", date: Timestamp.fromDate(new Date()) }],
     },
   ],
 });
@@ -78,4 +88,10 @@ export const editFileSubName = atom<string>({
 export const SelectProps = atom<string | null>({
   key: "selProps",
   default: null,
+});
+
+// Select 외부 영역 클릭 상태 관리
+export const SelectState = atom<boolean>({
+  key: "isClickOutsideState",
+  default: false,
 });


### PR DESCRIPTION
## 이슈 번호

Closes #52 

## 작업 내용
1. 파일의 최종 수정일을 추가했습니다.
 - 최초 작성일 = 최종 수정일
 - 수정시 최종 수정일

2. 폴더 메뉴 토글시 외부 영역을 클릭하면 토글이 닫히도록 수정했습니다.

3. 폴더 및 파일을 날짜순으로 정렬합니다.

4. 드롭앤드롭(React-beautiful-dnd) 정렬 라이브러리 적용했습니다.
- 폴더만 가능합니다.
- 맵핑구조(폴더 1 > 파일 1, 2, 3 ... 렌더링 => 폴더 2 > 파일 1, 2, 3 ...)가 이런식이라 파일은 너무 힘들 것 같아서 적용하지 못했습니다.

5. 초기 렌더링 화면 살짝 수정했습니다.

## 리뷰 요청 사항
폴더 및 파일 삭제 메시지를 따로 표기하지 않으려고 합니다. (노션도 따로 삭제메시지를 띄우지 않더라구요!)
혹여나 띄우는게 낫다고 생각하시면 바로 만들어보겠습니다. 👍 
