### PR TITLE
Feat: 팀원 추가 시 이미 다른 팀에 속한 유저 중복 등록 방지

### DIFF
--- a/src/components/Employee/AddMemberModal.tsx
+++ b/src/components/Employee/AddMemberModal.tsx
@@ -38,10 +38,10 @@ export default function AddMemberModal({ onCancel }: { onCancel: () => void }) {
       ...data,
       photo: imageUrl,
     });
-    onCancel(); // 모달창 닫기
+    onCancel();
     console.log(previewUrl);
     if (previewUrl) {
-      URL.revokeObjectURL(previewUrl); // FIXME: 리렌더 안돼서 미리보기가 남아있음
+      URL.revokeObjectURL(previewUrl);
     }
     form.resetFields();
   };

--- a/src/components/Employee/AddMemberSelect.tsx
+++ b/src/components/Employee/AddMemberSelect.tsx
@@ -1,0 +1,73 @@
+import React, { useState, useEffect } from "react";
+import { Transfer, Form, message } from "antd";
+import { collection, getDocs } from "firebase/firestore";
+import { db } from "../../libs/firebase";
+import { Rule } from "antd/lib/form";
+import CustomForm from "../common/CustomForm";
+import { useTeamUserIds } from "../../hooks/Employee/useTeamUserIds";
+
+interface AddTeamMemberSelectProps {
+  onChange: (selectedUserIds: string[]) => void;
+  rules?: Rule[];
+}
+
+interface UserData {
+  key: string;
+  title: string;
+}
+
+function AddTeamMemberSelect({ onChange }: AddTeamMemberSelectProps) {
+  const [users, setUsers] = useState<UserData[]>([]);
+  const [selectedUserKeys, setSelectedUserKeys] = useState<string[]>([]);
+  const teamUserIds = useTeamUserIds();
+
+  useEffect(() => {
+    const fetchUsers = async () => {
+      try {
+        const userCollectionRef = collection(db, "Users");
+        const userSnapshot = await getDocs(userCollectionRef);
+        const userArray: UserData[] = [];
+
+        userSnapshot.forEach((doc) => {
+          const userData = { key: doc.id, title: doc.data().name || "" };
+          userArray.push(userData);
+        });
+
+        const filteredUserArray = userArray.filter(
+          (user) => !teamUserIds.includes(user.key),
+        );
+
+        setUsers(filteredUserArray);
+      } catch (error) {
+        console.error("Error fetching users:", error);
+        message.error("데이터를 불러올 수 없습니다!");
+      }
+    };
+
+    fetchUsers();
+  }, [teamUserIds]);
+
+  const handleUserChange = (nextSelectedKeys: string[]) => {
+    setSelectedUserKeys(nextSelectedKeys);
+    onChange(nextSelectedKeys);
+  };
+
+  const { required } = CustomForm.useValidate();
+
+  return (
+    <>
+      <Form.Item label="팀원" name="userId" rules={[required()]}>
+        <Transfer
+          dataSource={users}
+          targetKeys={selectedUserKeys}
+          onChange={handleUserChange}
+          render={(item) => item.title}
+          showSearch
+          listStyle={{ width: "100%" }}
+        />
+      </Form.Item>
+    </>
+  );
+}
+
+export default AddTeamMemberSelect;

--- a/src/components/Employee/AddTeamModal.tsx
+++ b/src/components/Employee/AddTeamModal.tsx
@@ -8,6 +8,7 @@ import CustomForm from "../common/CustomForm";
 import styled from "styled-components";
 import { useRecoilState } from "recoil";
 import { selectedUserIdsState } from "../../store/member";
+import TeamMemberSelect from "./TeamMemberSelect";
 
 const COLLECTION_NAME = "Teams";
 
@@ -44,6 +45,9 @@ export default function AddTeamModal({ onCancel }: { onCancel: () => void }) {
       form={form}
     >
       <TeamForm isEditMode={isEditMode} />
+      <TeamMemberSelect
+        onChange={(userIds: string[]) => setSelectedUserIds(userIds)}
+      />
       <SumbitBtn>
         <Button htmlType="submit" type="primary">
           Add

--- a/src/components/Employee/EditMemberSelect.tsx
+++ b/src/components/Employee/EditMemberSelect.tsx
@@ -1,0 +1,95 @@
+import React, { useState, useEffect } from "react";
+import { Transfer, Form, message } from "antd";
+import { collection, getDocs } from "firebase/firestore";
+import { db } from "../../libs/firebase";
+import { Rule } from "antd/lib/form";
+import CustomForm from "../common/CustomForm";
+import { useTeamUserIds } from "../../hooks/Employee/useTeamUserIds";
+
+interface EditTeamMemberSelectProps {
+  onChange: (selectedUserIds: string[]) => void;
+  rules?: Rule[];
+  prevUserIds?: string[];
+}
+
+interface UserData {
+  key: string;
+  title: string;
+}
+
+function EditTeamMemberSelect({
+  prevUserIds,
+  onChange,
+}: EditTeamMemberSelectProps) {
+  const [users, setUsers] = useState<UserData[]>([]);
+  const [selectedUserKeys, setSelectedUserKeys] = useState<string[]>([]);
+
+  const teamUserIds = useTeamUserIds();
+
+  useEffect(() => {
+    const fetchUsers = async () => {
+      try {
+        const userCollectionRef = collection(db, "Users");
+        const userSnapshot = await getDocs(userCollectionRef);
+        const userArray: UserData[] = [];
+
+        userSnapshot.forEach((doc) => {
+          const userData = { key: doc.id, title: doc.data().name || "" };
+          userArray.push(userData);
+        });
+
+        const filteredUserArray = userArray.filter(
+          (user) => !teamUserIds.includes(user.key),
+        );
+
+        if (prevUserIds && prevUserIds.length > 0) {
+          prevUserIds.forEach((userId) => {
+            const userToAdd = userArray.find((user) => user.key === userId);
+            if (userToAdd) {
+              filteredUserArray.push(userToAdd);
+            }
+          });
+        }
+
+        setUsers(filteredUserArray);
+
+        if (prevUserIds && prevUserIds.length > 0) {
+          const selectedKeys = userArray
+            .filter((user) => prevUserIds.includes(user.key))
+            .map((user) => user.key);
+
+          setSelectedUserKeys(selectedKeys);
+        }
+      } catch (error) {
+        console.error("Error fetching users:", error);
+        message.error("데이터를 불러올 수 없습니다!");
+      }
+    };
+
+    fetchUsers();
+  }, [prevUserIds, teamUserIds]);
+
+  const handleUserChange = (nextSelectedKeys: string[]) => {
+    setSelectedUserKeys(nextSelectedKeys);
+    onChange(nextSelectedKeys);
+  };
+
+  const { required } = CustomForm.useValidate();
+
+  return (
+    <>
+      <Form.Item label="팀원" name="userId" rules={[required()]}>
+        <Transfer
+          dataSource={users}
+          targetKeys={selectedUserKeys}
+          onChange={handleUserChange}
+          render={(item) => item.title}
+          showSearch
+          listStyle={{ width: "100%" }}
+        />
+      </Form.Item>
+    </>
+  );
+}
+
+export default EditTeamMemberSelect;

--- a/src/components/Employee/MemberTable.tsx
+++ b/src/components/Employee/MemberTable.tsx
@@ -24,7 +24,7 @@ export default function MemberTable({
     ORDER: "name",
   };
   const data = useFetchData(fetchDataParams);
-  // const initialUserData: FormDataType[] = useFetchData(fetchDataParams);
+
   const [filteredData, setFilteredData] = useState<FormDataType[]>(data);
   const navigate = useNavigate();
 

--- a/src/components/Employee/TeamDetailInfo.tsx
+++ b/src/components/Employee/TeamDetailInfo.tsx
@@ -13,7 +13,8 @@ import {
 } from "../../hooks/Employee/useMemberMutaion";
 import TeamForm from "./TeamForm";
 import { useRecoilState } from "recoil";
-import { userIdsState } from "../../store/member";
+import { selectedUserIdsState, userIdsState } from "../../store/member";
+import EditMemberSelect from "./EditMemberSelect";
 
 function TeamDetailInfo() {
   const Form = CustomForm.Form;
@@ -31,8 +32,10 @@ function TeamDetailInfo() {
   const [cardName, setCardName] = useState(userData.name || userData.teamName);
   const [cardDepartment, setCardDepartment] = useState(userData.photo);
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [selectedUserIds, setSelectedUserIds] =
+    useRecoilState(selectedUserIdsState);
 
-  const [prevUserIds, setPrevUserIds] = useRecoilState(userIdsState);
+  const [prevUserIds, setPrevUserIds] = useState<string[]>([]);
 
   useEffect(() => {
     if (userData) {
@@ -125,6 +128,10 @@ function TeamDetailInfo() {
         <div className="member-info-area">
           <div className="member-info-wrap">
             <TeamForm isEditMode={isEditMode} />
+            <EditMemberSelect
+              onChange={(userIds: string[]) => setSelectedUserIds(userIds)}
+              prevUserIds={prevUserIds}
+            />
           </div>
         </div>
       </div>

--- a/src/components/Employee/TeamForm.tsx
+++ b/src/components/Employee/TeamForm.tsx
@@ -2,14 +2,8 @@ import React from "react";
 import { Divider } from "antd";
 import CustomForm from "../common/CustomForm";
 import { teamInputs, teamSelect } from "../../data/formSource";
-import { useRecoilState } from "recoil";
-import { selectedUserIdsState } from "../../store/member";
-import TeamMemberSelect from "./TeamMemberSelect";
 
 function TeamForm({ isEditMode }: { isEditMode: boolean }) {
-  const [selectedUserIds, setSelectedUserIds] =
-    useRecoilState(selectedUserIdsState);
-
   return (
     <>
       <Divider orientation="left">기본 정보</Divider>
@@ -33,9 +27,6 @@ function TeamForm({ isEditMode }: { isEditMode: boolean }) {
           readOnly={!isEditMode}
         />
       ))}
-      <TeamMemberSelect
-        onChange={(userIds: string[]) => setSelectedUserIds(userIds)}
-      />
     </>
   );
 }

--- a/src/components/Employee/TeamMemberSelect.tsx
+++ b/src/components/Employee/TeamMemberSelect.tsx
@@ -1,11 +1,12 @@
 import React, { useState, useEffect } from "react";
-import { Transfer, Form } from "antd";
+import { Transfer, Form, message } from "antd";
 import { collection, getDocs } from "firebase/firestore";
 import { db } from "../../libs/firebase";
 import { Rule } from "antd/lib/form";
 import CustomForm from "../common/CustomForm";
 import { userIdsState } from "../../store/member";
 import { useRecoilState } from "recoil";
+import { useTeamUserIds } from "../../hooks/Employee/useTeamUserIds";
 
 interface MemberSelectProps {
   onChange: (selectedUserIds: string[]) => void;
@@ -21,30 +22,41 @@ function TeamMemberSelect({ onChange }: MemberSelectProps) {
   const [users, setUsers] = useState<UserData[]>([]);
   const [selectedUserKeys, setSelectedUserKeys] = useState<string[]>([]);
   const [prevUserIds, setPrevUserIds] = useRecoilState(userIdsState);
+  const teamUserIds = useTeamUserIds(); // useTeamUserIds 훅을 사용하여 각 팀에 속한 사용자 ID를 가져옵니다.
 
   useEffect(() => {
     const fetchUsers = async () => {
-      const userCollectionRef = collection(db, "Users");
-      const userSnapshot = await getDocs(userCollectionRef);
-      const userArray: UserData[] = [];
+      try {
+        const userCollectionRef = collection(db, "Users");
+        const userSnapshot = await getDocs(userCollectionRef);
+        const userArray: UserData[] = [];
 
-      userSnapshot.forEach((doc) => {
-        const userData = { key: doc.id, title: doc.data().name || "" };
-        userArray.push(userData);
-      });
-      setUsers(userArray);
+        userSnapshot.forEach((doc) => {
+          const userData = { key: doc.id, title: doc.data().name || "" };
+          userArray.push(userData);
+        });
 
-      if (prevUserIds && prevUserIds.length > 0) {
-        const selectedKeys = userArray
-          .filter((user) => prevUserIds.includes(user.key))
-          .map((user) => user.key);
+        const filteredUserArray = userArray.filter(
+          (user) => !teamUserIds.includes(user.key),
+        );
 
-        setSelectedUserKeys(selectedKeys);
+        setUsers(filteredUserArray);
+
+        if (prevUserIds && prevUserIds.length > 0) {
+          const selectedKeys = userArray
+            .filter((user) => prevUserIds.includes(user.key))
+            .map((user) => user.key);
+
+          setSelectedUserKeys(selectedKeys);
+        }
+      } catch (error) {
+        console.error("Error fetching users:", error);
+        message.error("데이터를 불러올 수 없습니다!");
       }
     };
 
     fetchUsers();
-  }, [prevUserIds]);
+  }, [prevUserIds, teamUserIds]);
 
   const handleUserChange = (nextSelectedKeys: string[]) => {
     setSelectedUserKeys(nextSelectedKeys);

--- a/src/components/Employee/TeamMemberSelect.tsx
+++ b/src/components/Employee/TeamMemberSelect.tsx
@@ -22,7 +22,7 @@ function TeamMemberSelect({ onChange }: MemberSelectProps) {
   const [users, setUsers] = useState<UserData[]>([]);
   const [selectedUserKeys, setSelectedUserKeys] = useState<string[]>([]);
   const [prevUserIds, setPrevUserIds] = useRecoilState(userIdsState);
-  const teamUserIds = useTeamUserIds(); // useTeamUserIds 훅을 사용하여 각 팀에 속한 사용자 ID를 가져옵니다.
+  const teamUserIds = useTeamUserIds();
 
   useEffect(() => {
     const fetchUsers = async () => {

--- a/src/hooks/Employee/useTeamUserIds.ts
+++ b/src/hooks/Employee/useTeamUserIds.ts
@@ -1,0 +1,32 @@
+import { useState, useEffect } from "react";
+import { db } from "../../libs/firebase";
+import { collection, getDocs, DocumentReference } from "firebase/firestore";
+import { message } from "antd";
+
+export function useTeamUserIds() {
+  const [teamUserIds, setTeamUserIds] = useState<string[]>([]);
+
+  useEffect(() => {
+    const fetchTeamUserIds = async () => {
+      try {
+        const teamsCollectionRef = collection(db, "Teams");
+        const teamsSnapshot = await getDocs(teamsCollectionRef);
+        const userIds: string[] = [];
+
+        teamsSnapshot.forEach((teamDoc) => {
+          const userData: string[] = teamDoc.data().userId || [];
+          userIds.push(...userData);
+        });
+
+        setTeamUserIds(userIds);
+      } catch (error) {
+        console.error("Error fetching team user IDs:", error);
+        message.error("데이터를 불러올 수 없습니다!");
+      }
+    };
+
+    fetchTeamUserIds();
+  }, []);
+
+  return teamUserIds;
+}


### PR DESCRIPTION
## 이슈 번호

Closes #69 

## 작업 내용
- 이미 다른 팀에 속한 유저를 중복 등록하지 못하도록 유저목록 불러오는 과정에서 필터링 처리 했습니다!

## 리뷰 요청 사항
문제되는 부분있으면 말씀부탁드립니다!! 😄