### PR TITLE
Feat: 프로젝트 페이지 필터링 추가

### DIFF
--- a/src/components/project/ProjectDetailInfo.tsx
+++ b/src/components/project/ProjectDetailInfo.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import React from "react";
 import "@toast-ui/editor/dist/toastui-editor-viewer.css";
-import { Button, Popconfirm } from "antd";
+import { Breadcrumb, Button, Popconfirm } from "antd";
 import { DeleteFilled, EditFilled } from "@ant-design/icons";
 import ProjectDate from "./ProjectDate";
 import ProjectAssignee from "./ProjectAssignee";
@@ -20,42 +20,60 @@ const ProjectDetailInfo = ({
   const navigate = useNavigate();
 
   return (
-    <div className="project-container">
-      <div className="project__top-title">
-        <h3>프로젝트 상세 정보</h3>
-        <div className="project__top-btns">
-          <Button
-            type="primary"
-            icon={<EditFilled />}
-            size="large"
-            onClick={() => {
-              navigate(`/project/${projectDetail?.id}/edit`);
-            }}
-          >
-            프로젝트 수정
-          </Button>
-          <Popconfirm
-            title="프로젝트 삭제"
-            description="정말로 삭제하시겠습니까?"
-            okText="예"
-            cancelText="아니오"
-            onConfirm={() => {
-              void onClickDelete(projectDetail!.id!, projectDetail!.status);
-              navigate(`/project/all`);
-            }}
-          >
-            <Button danger icon={<DeleteFilled />} size="large">
-              프로젝트 삭제
-            </Button>
-          </Popconfirm>
-        </div>
+    <>
+      <div style={{ marginBottom: "12px" }}>
+        <Breadcrumb
+          items={[
+            { title: "프로젝트" },
+            {
+              title:
+                projectDetail?.status === "plus"
+                  ? "예정된 프로젝트"
+                  : projectDetail?.status === "progress"
+                  ? "진행중인 프로젝트"
+                  : "완료된 프로젝트",
+            },
+            { title: projectDetail?.title },
+          ]}
+        />
       </div>
-      <h2>{projectDetail?.title}</h2>
-      <ProjectDate duration={projectDetail?.duration} />
-      <ProjectAssignee assignees={projectDetail?.assignees} />
-      <ProjectTeams teams={projectDetail?.teams} />
-      <Viewer initialValue={projectDetail?.data} />
-    </div>
+      <div className="project-container">
+        <div className="project__top-title">
+          <h3>프로젝트 상세 정보</h3>
+          <div className="project__top-btns">
+            <Button
+              type="primary"
+              icon={<EditFilled />}
+              size="large"
+              onClick={() => {
+                navigate(`/project/${projectDetail?.id}/edit`);
+              }}
+            >
+              프로젝트 수정
+            </Button>
+            <Popconfirm
+              title="프로젝트 삭제"
+              description="정말로 삭제하시겠습니까?"
+              okText="예"
+              cancelText="아니오"
+              onConfirm={() => {
+                void onClickDelete(projectDetail!.id!, projectDetail!.status);
+                navigate(`/project/all`);
+              }}
+            >
+              <Button danger icon={<DeleteFilled />} size="large">
+                프로젝트 삭제
+              </Button>
+            </Popconfirm>
+          </div>
+        </div>
+        <h2>{projectDetail?.title}</h2>
+        <ProjectDate duration={projectDetail?.duration} />
+        <ProjectAssignee assignees={projectDetail?.assignees} />
+        <ProjectTeams teams={projectDetail?.teams} />
+        <Viewer initialValue={projectDetail?.data} />
+      </div>
+    </>
   );
 };
 

--- a/src/components/project/ProjectListItem.tsx
+++ b/src/components/project/ProjectListItem.tsx
@@ -29,12 +29,20 @@ const ProjectStatus = styled.div<{ $status: string }>`
       : "lightgray"};
 `;
 
-const ProjectListItem = ({ project }: { project: ProjectInfo }) => {
+const ProjectListItem = ({
+  project,
+  status,
+}: {
+  project: ProjectInfo;
+  status: string | null;
+}) => {
   const navigate = useNavigate();
   return (
     <ProjectItem
       onClick={() => {
-        navigate(`/project/${project.id}`);
+        navigate(
+          `/project/${status ? project.id + "?status=" + status : project.id}`,
+        );
       }}
     >
       <div>

--- a/src/components/project/ProjectListSider.tsx
+++ b/src/components/project/ProjectListSider.tsx
@@ -1,25 +1,21 @@
-import React, { useEffect } from "react";
+import React from "react";
 import ProjectListItem from "./ProjectListItem";
 import useQueryProjectAllList from "../../hooks/project/useQueryProjectAllList";
+import useQueryParam from "../../hooks/project/useQueryParam";
 
 const ProjectListSider = () => {
+  const status = useQueryParam().get("status");
   const projects = useQueryProjectAllList();
-  const projectArr = [
-    ...projects["plus"],
-    ...projects["progress"],
-    ...projects["completed"],
-  ];
+  const projectArr =
+    status === null
+      ? [...projects["plus"], ...projects["progress"], ...projects["completed"]]
+      : [...projects[status]];
   projectArr.sort((a, b) => b.createdAt.toMillis() - a.createdAt.toMillis());
-
-  useEffect(() => {
-    console.log("list is rendering");
-    console.log(projectArr);
-  });
 
   return (
     <div className="project__all-list">
       {projectArr?.map((project) => (
-        <ProjectListItem key={project.id} project={project} />
+        <ProjectListItem key={project.id} project={project} status={status} />
       ))}
     </div>
   );

--- a/src/components/project/ProjectListSider.tsx
+++ b/src/components/project/ProjectListSider.tsx
@@ -76,7 +76,7 @@ const ProjectListSider = () => {
           <Dropdown menu={{ items: userItems, onClick: filterByUser }}>
             <Button size={"small"}>
               <Space>
-                담당자
+                {selectedUser === "" ? "담당자" : selectedUser.substring(0, 3)}
                 <DownOutlined />
               </Space>
             </Button>
@@ -84,7 +84,7 @@ const ProjectListSider = () => {
           <Dropdown menu={{ items: teamItems, onClick: filterByTeam }}>
             <Button size={"small"}>
               <Space>
-                팀명
+                {selectedTeam === "" ? "팀명" : selectedTeam.substring(0, 3)}
                 <DownOutlined />
               </Space>
             </Button>

--- a/src/components/project/ProjectListSider.tsx
+++ b/src/components/project/ProjectListSider.tsx
@@ -1,23 +1,111 @@
-import React from "react";
+import React, { useState } from "react";
 import ProjectListItem from "./ProjectListItem";
 import useQueryProjectAllList from "../../hooks/project/useQueryProjectAllList";
 import useQueryParam from "../../hooks/project/useQueryParam";
+import { Button, Dropdown, MenuProps, Skeleton, Space } from "antd";
+import useQueryProjectEdit from "../../hooks/project/useQueryProjectEdit";
+import { DownOutlined, RedoOutlined } from "@ant-design/icons";
 
 const ProjectListSider = () => {
+  const [selectedTeam, setSelectedTeam] = useState("");
+  const [selectedUser, setSelectedUser] = useState("");
   const status = useQueryParam().get("status");
+  const [teams, users, , isLoaded] = useQueryProjectEdit();
   const projects = useQueryProjectAllList();
-  const projectArr =
+  let projectArr =
     status === null
       ? [...projects["plus"], ...projects["progress"], ...projects["completed"]]
       : [...projects[status]];
   projectArr.sort((a, b) => b.createdAt.toMillis() - a.createdAt.toMillis());
 
+  // 팀명을 드롭다운 아이템 형식으로 변경하기
+  const teamItems: MenuProps["items"] = teams?.map((team, index) => {
+    return { key: index, label: team.teamName };
+  });
+  // 담당자명을 드롭다운 아이텀 형식으로 변경하기
+  const userItems: MenuProps["items"] = users?.map((user, index) => {
+    return { key: index, label: user.name };
+  });
+
+  const filterByTeam: MenuProps["onClick"] = ({ key }) => {
+    // antdesign 측에서 타입을 이상하게 해서 string > json으로 변환하여 진행
+    const findTeam = teamItems?.find((team) => team?.key === Number(key));
+    const team = JSON.stringify(findTeam);
+    const { label } = JSON.parse(team);
+    setSelectedTeam(label);
+  };
+
+  const filterByUser: MenuProps["onClick"] = ({ key }) => {
+    // 유저정보를 가져오기
+    const findUser = userItems?.find((user) => user?.key === Number(key));
+    const user = JSON.stringify(findUser);
+    const { label } = JSON.parse(user);
+    setSelectedUser(label);
+  };
+
+  const onClickReset = () => {
+    setSelectedTeam("");
+    setSelectedUser("");
+    projectArr =
+      status === null
+        ? [
+            ...projects["plus"],
+            ...projects["progress"],
+            ...projects["completed"],
+          ]
+        : [...projects[status]];
+  };
+
+  if (selectedTeam !== "") {
+    const selectedProj = projectArr.filter(
+      (proj) => proj.teams.indexOf(selectedTeam) > -1,
+    );
+    projectArr = selectedProj;
+  }
+  if (selectedUser !== "") {
+    const selectedProj = projectArr.filter(
+      (proj) => proj.assignees.indexOf(selectedUser) > -1,
+    );
+    projectArr = selectedProj;
+  }
+
   return (
-    <div className="project__all-list">
-      {projectArr?.map((project) => (
-        <ProjectListItem key={project.id} project={project} status={status} />
-      ))}
-    </div>
+    <>
+      {isLoaded ? (
+        <div className="project__filter">
+          <Dropdown menu={{ items: userItems, onClick: filterByUser }}>
+            <Button size={"small"}>
+              <Space>
+                담당자
+                <DownOutlined />
+              </Space>
+            </Button>
+          </Dropdown>
+          <Dropdown menu={{ items: teamItems, onClick: filterByTeam }}>
+            <Button size={"small"}>
+              <Space>
+                팀명
+                <DownOutlined />
+              </Space>
+            </Button>
+          </Dropdown>
+          <Button onClick={onClickReset} size={"small"}>
+            <Space>
+              초기화
+              <RedoOutlined />
+            </Space>
+          </Button>
+        </div>
+      ) : (
+        <Skeleton.Button />
+      )}
+
+      <div className="project__all-list">
+        {projectArr?.map((project) => (
+          <ProjectListItem key={project.id} project={project} status={status} />
+        ))}
+      </div>
+    </>
   );
 };
 

--- a/src/components/project/ProjectNewFormSkeleton.tsx
+++ b/src/components/project/ProjectNewFormSkeleton.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { Form, Skeleton } from "antd";
+
+const ProjectNewForm = () => {
+  const formTailLayout = {
+    labelCol: { md: { span: 4 }, xl: { span: 3 } },
+    wrapperCol: { md: { span: 14 }, xl: { span: 16 } },
+  };
+  return (
+    <div className="project-container">
+      <div className="project__top-title">
+        <h3>프로젝트 수정</h3>
+      </div>
+      <Form {...formTailLayout} layout="horizontal" colon={false}>
+        <Form.Item label=" ">
+          <div style={{ display: "flex", justifyContent: "flex-end" }}>
+            <Skeleton.Button active />
+          </div>
+        </Form.Item>
+        <Form.Item label="프로젝트 명:">
+          <Skeleton.Input active />
+        </Form.Item>
+        <Form.Item label="진행상황:">
+          <Skeleton.Input active />
+        </Form.Item>
+        <Form.Item label="담당자:">
+          <Skeleton.Input active />
+        </Form.Item>
+        <Form.Item label="프로젝트 담당:">
+          <Skeleton.Input active />
+        </Form.Item>
+        <Form.Item label="프로젝트 기간:">
+          <Skeleton.Input active />
+        </Form.Item>
+      </Form>
+      <Skeleton title={true} active />
+    </div>
+  );
+};
+
+export default ProjectNewForm;

--- a/src/components/project/ProjectSider.tsx
+++ b/src/components/project/ProjectSider.tsx
@@ -28,7 +28,12 @@ function getItem(
 }
 
 const items: MenuItem[] = [
-  getItem("전체 프로젝트", "all", <ProjectOutlined />),
+  getItem("프로젝트 상태 별 목록", "projects", <ProjectOutlined />, [
+    getItem("전체 프로젝트", "all"),
+    getItem("예정된 프로젝트", "plus"),
+    getItem("진행중인 프로젝트", "progress"),
+    getItem("완료된 프로젝트", "completed"),
+  ]),
   getItem("내 팀 프로젝트", "myteam", <ProjectOutlined />, [
     getItem("프론트엔드 개발팀", "fe", <UnorderedListOutlined />),
   ]),
@@ -62,6 +67,15 @@ const ProjectSider = () => {
       case "all":
         navigate("/project/all");
         break;
+      case "plus":
+        navigate("/project/all?status=plus");
+        break;
+      case "progress":
+        navigate("/project/all?status=progress");
+        break;
+      case "completed":
+        navigate("/project/all?status=completed");
+        break;
       case "fe":
         navigate("/project");
         break;
@@ -79,7 +93,7 @@ const ProjectSider = () => {
         onClick={onClick}
         style={{ width: 200 }}
         defaultSelectedKeys={[currentPath ?? "fe"]}
-        defaultOpenKeys={["myteam"]}
+        defaultOpenKeys={["myteam", "projects"]}
         mode="inline"
         items={items}
       />

--- a/src/hooks/project/useMutationDelProject.tsx
+++ b/src/hooks/project/useMutationDelProject.tsx
@@ -1,10 +1,9 @@
 import { deleteDoc, doc } from "firebase/firestore";
 import { db } from "../../libs/firebase";
 import { useSetRecoilState } from "recoil";
-import { projectDetailState, projectListState } from "../../store/project";
+import { projectListState } from "../../store/project";
 
 const useMutationDelProject = () => {
-  const setProjectDetail = useSetRecoilState(projectDetailState);
   const setProjectList = useSetRecoilState(projectListState);
   const onClickProjDelete = async (
     clickedId: string,
@@ -12,8 +11,6 @@ const useMutationDelProject = () => {
   ): Promise<void> => {
     // 클릭한 요소의 ID값을 가진 문서를 삭제
     await deleteDoc(doc(db, "Project", clickedId));
-    // 상세 정보 state도 초기화
-    setProjectDetail(undefined);
     // 삭제가 된 후에는 projects state도 변경합니다.(삭제된 버전을 다시 보여주기 위해서)
     setProjectList((oldProjs) => {
       const removedList = [...oldProjs[status]];

--- a/src/hooks/project/useMutationNewProject.tsx
+++ b/src/hooks/project/useMutationNewProject.tsx
@@ -19,8 +19,6 @@ import { ProjectDetail, projectDetailConverter } from "../../libs/firestore";
 import { useLocation, useNavigate } from "react-router-dom";
 import dayjs from "dayjs";
 import customParseFormat from "dayjs/plugin/customParseFormat";
-// import { useRecoilState } from "recoil";
-// import { isModifingState } from "../../store/project";
 
 type formValues = Pick<
   ProjectDetail,

--- a/src/hooks/project/useQueryParam.ts
+++ b/src/hooks/project/useQueryParam.ts
@@ -1,0 +1,9 @@
+import React from "react";
+import { useLocation } from "react-router-dom";
+
+const useQueryParam = () => {
+  const { search } = useLocation();
+
+  return React.useMemo(() => new URLSearchParams(search), [search]);
+};
+export default useQueryParam;

--- a/src/hooks/project/useQueryProject.tsx
+++ b/src/hooks/project/useQueryProject.tsx
@@ -15,7 +15,6 @@ export const useQueryProject = (): [
 
   useEffect(() => {
     if (projectId === undefined) return;
-    setIsLoaded(false);
     (async () => {
       try {
         const docRef = doc(db, "Project", projectId).withConverter(
@@ -33,7 +32,7 @@ export const useQueryProject = (): [
       }
     })();
     return () => {
-      console.log("unmount");
+      setIsLoaded(false);
     };
   }, [projectId]);
   return [projectDetail, isLoaded];

--- a/src/hooks/project/useQueryProjectAllList.tsx
+++ b/src/hooks/project/useQueryProjectAllList.tsx
@@ -10,7 +10,6 @@ const useQueryProjectAllList = () => {
   const [projects, setProjects] = useRecoilState(projectListState);
 
   useEffect(() => {
-    setIsLoading(true);
     (async () => {
       try {
         const projectPlus: ProjectInfo[] = [];
@@ -40,12 +39,15 @@ const useQueryProjectAllList = () => {
           progress: projectProgress,
           completed: projectCompleted,
         });
-        setIsLoading(false);
       } catch (error) {
-        setIsLoading(false);
         if (error instanceof Error) console.log(error.message);
+      } finally {
+        setIsLoading(false);
       }
     })();
+    return () => {
+      setIsLoading(true);
+    };
   }, []);
   return projects;
 };

--- a/src/hooks/project/useQueryProjectEdit.tsx
+++ b/src/hooks/project/useQueryProjectEdit.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect } from "react";
-import { useLocation } from "react-router-dom";
 import {
   ProjectDetail,
   TeamList,
@@ -11,14 +10,14 @@ import {
 import { collection, doc, getDoc, getDocs, query } from "firebase/firestore";
 import { db } from "../../libs/firebase";
 
-const useQueryProjectEdit = (): [
+const useQueryProjectEdit = (
+  projectId?: string,
+): [
   teams: TeamList[] | undefined,
   users: UserList[] | undefined,
   projectDetail: ProjectDetail | undefined,
   isLoaded: boolean,
 ] => {
-  const { pathname } = useLocation();
-  const projectId = pathname.split("/")[2];
   const [teams, setTeams] = useState<TeamList[]>();
   const [users, setUsers] = useState<UserList[]>();
   const [projectDetail, setProjectDetail] = useState<ProjectDetail>();
@@ -42,7 +41,9 @@ const useQueryProjectEdit = (): [
     });
     return data;
   };
-  const projectQuery = async (): Promise<ProjectDetail | undefined> => {
+  const projectQuery = async (
+    projectId: string,
+  ): Promise<ProjectDetail | undefined> => {
     const docRef = doc(db, "Project", projectId).withConverter(
       projectDetailConverter,
     );
@@ -63,7 +64,7 @@ const useQueryProjectEdit = (): [
         setTeams(team);
         setUsers(user);
         if (projectId) {
-          const project = await projectQuery();
+          const project = await projectQuery(projectId);
           setProjectDetail(project);
         }
       })();

--- a/src/libs/firestore.ts
+++ b/src/libs/firestore.ts
@@ -14,6 +14,7 @@ export class ProjectInfo {
     public order: number,
     public assignees: string[],
     public duration: string[],
+    public teams: string[],
     public createdAt: Timestamp,
   ) {}
   toString() {
@@ -45,6 +46,7 @@ export const projectConverter: FirestoreDataConverter<ProjectInfo> = {
       order: docData.order,
       assignees: docData.assignees,
       duration: docData.duration,
+      teams: docData.teams,
       createdAt: docData.createdAt,
     };
   },
@@ -61,6 +63,7 @@ export const projectConverter: FirestoreDataConverter<ProjectInfo> = {
       data.order,
       data.assignees,
       data.duration,
+      data.teams,
       data.createdAt,
     );
   },

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -12,7 +12,6 @@ const { Content, Sider } = Layout;
 const ProjectDetail = ({ isDefault }: { isDefault: boolean }) => {
   const [projectDetail, isLoaded] = useQueryProject();
 
-  console.log(isLoaded);
   return (
     <Layout>
       <ProjectSider />

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import "../styles/Project.css";
 import ProjectSider from "../components/project/ProjectSider";
-import { Layout } from "antd";
+import { Layout, Skeleton } from "antd";
 import ProjectDetailInfo from "../components/project/ProjectDetailInfo";
 import ProjectListSider from "../components/project/ProjectListSider";
 import { useQueryProject } from "../hooks/project/useQueryProject";
@@ -31,7 +31,14 @@ const ProjectDetail = ({ isDefault }: { isDefault: boolean }) => {
             <ProjectDetailDefault />
           ) : isLoaded ? (
             <ProjectDetailInfo projectDetail={projectDetail} />
-          ) : null}
+          ) : (
+            <div className="project-container">
+              <div className="project__top-title">
+                <h3>프로젝트 상세 정보</h3>
+              </div>
+              <Skeleton title={true} />
+            </div>
+          )}
         </Content>
       </Layout>
     </Layout>

--- a/src/pages/ProjectEdit.tsx
+++ b/src/pages/ProjectEdit.tsx
@@ -6,9 +6,13 @@ import { Layout } from "antd";
 import ProjectNewForm from "../components/project/ProjectNewForm";
 import ProjectNewFormSkeleton from "../components/project/ProjectNewFormSkeleton";
 import useQueryProjectEdit from "../hooks/project/useQueryProjectEdit";
+import { useLocation } from "react-router-dom";
 
 const ProjectEdit = ({ isEdit }: { isEdit: boolean }) => {
-  const [teams, users, projectDetail, isLoaded] = useQueryProjectEdit();
+  const { pathname } = useLocation();
+  const projectId = pathname.split("/")[2];
+  const [teams, users, projectDetail, isLoaded] =
+    useQueryProjectEdit(projectId);
   return (
     <>
       {isLoaded ? (

--- a/src/pages/ProjectEdit.tsx
+++ b/src/pages/ProjectEdit.tsx
@@ -4,25 +4,28 @@ import ProjectSider from "../components/project/ProjectSider";
 // import { Layout, theme } from "antd";
 import { Layout } from "antd";
 import ProjectNewForm from "../components/project/ProjectNewForm";
+import ProjectNewFormSkeleton from "../components/project/ProjectNewFormSkeleton";
 import useQueryProjectEdit from "../hooks/project/useQueryProjectEdit";
 
 const ProjectEdit = ({ isEdit }: { isEdit: boolean }) => {
   const [teams, users, projectDetail, isLoaded] = useQueryProjectEdit();
   return (
     <>
-      {!isLoaded ? null : (
+      {isLoaded ? (
         <Layout>
           <ProjectSider />
-          {projectDetail !== undefined && (
+          {projectDetail !== undefined ? (
             <ProjectNewForm
               isEdit={isEdit}
               teams={teams}
               users={users}
               projectDetail={projectDetail}
             />
+          ) : (
+            <ProjectNewFormSkeleton />
           )}
         </Layout>
-      )}
+      ) : null}
     </>
   );
 };

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -1,14 +1,6 @@
 import { atom } from "recoil";
-import { ProjectDetail, ProjectInfo } from "../libs/firestore";
+import { ProjectInfo } from "../libs/firestore";
 
-export const projectDetailState = atom<ProjectDetail | undefined>({
-  key: `projectDetailState`,
-  default: undefined,
-});
-export const isModifingState = atom({
-  key: "isModifingState",
-  default: false,
-});
 export const isLoadingState = atom({
   key: "isLoadingState",
   default: false,

--- a/src/styles/Project.css
+++ b/src/styles/Project.css
@@ -40,3 +40,11 @@
     padding-right: 24px;
     padding-bottom: 24px;
 }
+
+.project__filter{
+    height: 43px;
+    padding: 6px 12px;
+    font-size: 12px;
+    display: flex;
+    justify-content: space-between;
+}


### PR DESCRIPTION
## 이슈 번호

Closes #71 

## 작업 내용
1. 전체 프로젝트 > 예정된, 진행중, 완료된 프로젝트로 나누었습니다.
2. 프로젝트 목록이 많아지면 찾기 힘들어질 수 있기 때문에 필터링 기능을 추가하였습니다.
3. 로딩시 화면이 툭툭 튀는것 같아서 스켈레톤도 적용했습니다.

## 리뷰 요청 사항
firebase에 새로운 정보를 요청 보내는것이 아니라
기존 리스트를 필터링 하는 기능이라서 db에서 불러오지 않습니다.
혹시 이렇게 해도 문제는 없을까요?