### PR TITLE
Feat: 팀 상세정보 페이지 업로드 로딩 기능

### DIFF
--- a/src/components/Employee/EditMemberSelect.tsx
+++ b/src/components/Employee/EditMemberSelect.tsx
@@ -7,6 +7,7 @@ import CustomForm from "../common/CustomForm";
 import { useTeamUserIds } from "../../hooks/Employee/useTeamUserIds";
 
 interface EditTeamMemberSelectProps {
+  isEditMode: boolean;
   onChange: (selectedUserIds: string[]) => void;
   rules?: Rule[];
   prevUserIds?: string[];
@@ -18,6 +19,7 @@ interface UserData {
 }
 
 function EditTeamMemberSelect({
+  isEditMode,
   prevUserIds,
   onChange,
 }: EditTeamMemberSelectProps) {
@@ -86,6 +88,7 @@ function EditTeamMemberSelect({
           render={(item) => item.title}
           showSearch
           listStyle={{ width: "100%" }}
+          disabled={!isEditMode}
         />
       </Form.Item>
     </>

--- a/src/components/Employee/MemberDetailInfo.tsx
+++ b/src/components/Employee/MemberDetailInfo.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useState } from "react";
-import { useParams } from "react-router-dom";
+import { useParams, useNavigate } from "react-router-dom";
 import { useFetchData } from "../../hooks/Employee/useFetchData";
 import { FormDataType } from "../../type/form";
 import { Button, message } from "antd";
 import CustomForm from "../common/CustomForm";
-import { EditOutlined } from "@ant-design/icons";
+import { EditOutlined, UnorderedListOutlined } from "@ant-design/icons";
 import MemberForm from "./MemberForm";
 import MemberProfile from "./MemberProfile";
 import {
@@ -18,6 +18,7 @@ function MemberDetailInfo() {
   const [form] = Form.useForm();
   const [isEditMode, setIsEditMode] = useState(false);
   const [file, setFile] = useState<File | null>(null); // file 관리
+  const navigate = useNavigate();
   const { memberId } = useParams<{ memberId: string }>();
   const fetchDataParams = {
     COLLECTION_NAME: "Users",
@@ -88,6 +89,14 @@ function MemberDetailInfo() {
           <span className="member-desc">{userData?.name} 님의 프로필</span>
         </div>
         <div className="member-btn-area">
+          <Button
+            icon={<UnorderedListOutlined />}
+            onClick={() => {
+              navigate(-1);
+            }}
+          >
+            목록
+          </Button>
           <Button
             type="primary"
             icon={<EditOutlined />}

--- a/src/components/Employee/MemberDetailInfo.tsx
+++ b/src/components/Employee/MemberDetailInfo.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { useFetchData } from "../../hooks/Employee/useFetchData";
 import { FormDataType } from "../../type/form";
-import { Button, message } from "antd";
+import { Button, message, Spin } from "antd";
 import CustomForm from "../common/CustomForm";
 import { EditOutlined, UnorderedListOutlined } from "@ant-design/icons";
 import MemberForm from "./MemberForm";
@@ -12,6 +12,7 @@ import {
   useUploadStorage,
   useDeleteStorage,
 } from "../../hooks/Employee/useMemberMutaion";
+import styled from "styled-components";
 
 function MemberDetailInfo() {
   const Form = CustomForm.Form;
@@ -28,6 +29,7 @@ function MemberDetailInfo() {
   const [cardName, setCardName] = useState(userData.name);
   const [cardDepartment, setCardDepartment] = useState(userData.photo);
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
   useEffect(() => {
     if (userData) {
       Object.keys(userData).forEach((fieldName) => {
@@ -43,6 +45,7 @@ function MemberDetailInfo() {
 
   const handleUpdate = async () => {
     try {
+      setLoading(true);
       const { uploadStorage } = useUploadStorage();
       const { deleteStorage } = useDeleteStorage();
       const { updateData } = useUpdateData({ COLLECTION_NAME: "Users" });
@@ -64,6 +67,8 @@ function MemberDetailInfo() {
     } catch (error) {
       console.error("Error updating member:", error);
       message.error("데이터 업데이트 중 오류가 발생했습니다");
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -83,6 +88,11 @@ function MemberDetailInfo() {
 
   return (
     <Form form={form}>
+      {loading ? (
+        <Overlay>
+          <Spin size="large" />
+        </Overlay>
+      ) : null}
       <div className="member-header">
         <div className="member-title">
           <h3>직원 정보</h3>
@@ -135,3 +145,16 @@ function MemberDetailInfo() {
   );
 }
 export default MemberDetailInfo;
+
+const Overlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(255, 255, 255, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+`;

--- a/src/components/Employee/TeamDetailInfo.tsx
+++ b/src/components/Employee/TeamDetailInfo.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useState } from "react";
-import { useParams } from "react-router-dom";
+import { useParams, useNavigate } from "react-router-dom";
 import { useFetchData } from "../../hooks/Employee/useFetchData";
 import { FormDataType } from "../../type/form";
 import { Button, message } from "antd";
 import CustomForm from "../common/CustomForm";
-import { EditOutlined } from "@ant-design/icons";
+import { EditOutlined, UnorderedListOutlined } from "@ant-design/icons";
 import MemberProfile from "./MemberProfile";
 import {
   useUpdateData,
@@ -21,6 +21,7 @@ function TeamDetailInfo() {
   const [form] = Form.useForm();
   const [isEditMode, setIsEditMode] = useState(false);
   const [file, setFile] = useState<File | null>(null);
+  const navigate = useNavigate();
   const { teamId } = useParams<{
     teamId: string;
   }>();
@@ -97,6 +98,14 @@ function TeamDetailInfo() {
           <span className="member-desc">{userData.teamName} 팀 프로필</span>
         </div>
         <div className="member-btn-area">
+          <Button
+            icon={<UnorderedListOutlined />}
+            onClick={() => {
+              navigate(-1);
+            }}
+          >
+            목록
+          </Button>
           <Button
             type="primary"
             icon={<EditOutlined />}

--- a/src/components/Employee/TeamDetailInfo.tsx
+++ b/src/components/Employee/TeamDetailInfo.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { useFetchData } from "../../hooks/Employee/useFetchData";
 import { FormDataType } from "../../type/form";
-import { Button, message } from "antd";
+import { Button, message, Spin } from "antd";
 import CustomForm from "../common/CustomForm";
 import { EditOutlined, UnorderedListOutlined } from "@ant-design/icons";
 import MemberProfile from "./MemberProfile";
@@ -15,6 +15,7 @@ import TeamForm from "./TeamForm";
 import { useRecoilState } from "recoil";
 import { selectedUserIdsState, userIdsState } from "../../store/member";
 import EditMemberSelect from "./EditMemberSelect";
+import styled from "styled-components";
 
 function TeamDetailInfo() {
   const Form = CustomForm.Form;
@@ -35,8 +36,8 @@ function TeamDetailInfo() {
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [selectedUserIds, setSelectedUserIds] =
     useRecoilState(selectedUserIdsState);
-
   const [prevUserIds, setPrevUserIds] = useState<string[]>([]);
+  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     if (userData) {
@@ -54,6 +55,8 @@ function TeamDetailInfo() {
 
   const handleUpdate = async () => {
     try {
+      setLoading(true);
+
       const { uploadStorage } = useUploadStorage();
       const { deleteStorage } = useDeleteStorage();
       const { updateData } = useUpdateData({ COLLECTION_NAME: "Teams" });
@@ -62,7 +65,7 @@ function TeamDetailInfo() {
       if (file !== null) {
         const downloadURL = await uploadStorage(file as File);
         fieldsValue.photo = downloadURL;
-        if (userData.photo) {
+        if (userData?.photo) {
           await deleteStorage(userData.photo);
         }
       }
@@ -74,6 +77,8 @@ function TeamDetailInfo() {
     } catch (error) {
       console.error("Error updating member:", error);
       message.error("데이터 업데이트 중 오류가 발생했습니다");
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -92,6 +97,11 @@ function TeamDetailInfo() {
 
   return (
     <Form form={form}>
+      {loading ? (
+        <Overlay>
+          <Spin size="large" />
+        </Overlay>
+      ) : null}
       <div className="member-header">
         <div className="member-title">
           <h3>팀 정보</h3>
@@ -149,3 +159,16 @@ function TeamDetailInfo() {
   );
 }
 export default TeamDetailInfo;
+
+const Overlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(255, 255, 255, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+`;

--- a/src/components/Employee/TeamDetailInfo.tsx
+++ b/src/components/Employee/TeamDetailInfo.tsx
@@ -129,6 +129,7 @@ function TeamDetailInfo() {
           <div className="member-info-wrap">
             <TeamForm isEditMode={isEditMode} />
             <EditMemberSelect
+              isEditMode={isEditMode}
               onChange={(userIds: string[]) => setSelectedUserIds(userIds)}
               prevUserIds={prevUserIds}
             />

--- a/src/styles/Employee.css
+++ b/src/styles/Employee.css
@@ -83,6 +83,13 @@
     padding: 3rem;
 }
 
+.member-btn-area > button {
+    margin-right: 10px;
+}
+.member-btn-area > button:last-child {
+    margin: 0;
+}
+
 /* custom antd style */
 .ant-input[readonly]{
     border: 0;


### PR DESCRIPTION
## 이슈 번호

Closes #63

## 작업 내용
 - 팀 상세정보페이지 편집모드 일 때 트랜스퍼 disabled 적용
 - 팀 상세정보페이지 목록으로 되돌아가기 버튼 생성
 - 팀 상세정보페이지 업데이트 시 로딩 기능 구현 

## 리뷰 요청 사항
문제있거나 개선이 필요한 부분 있으면 말씀부탁드립니다!!