### PR TITLE
Feat: 로그인 유저정보 연동

### DIFF
--- a/src/components/Wiki/WikiSubPage.tsx
+++ b/src/components/Wiki/WikiSubPage.tsx
@@ -35,6 +35,7 @@ export interface IItem {
   name?: string;
   position?: string;
   department?: string;
+  photo?: string;
 }
 
 const SubPage = () => {

--- a/src/components/Wiki/WikiTeamNav.tsx
+++ b/src/components/Wiki/WikiTeamNav.tsx
@@ -133,6 +133,7 @@ const WikiTeamNav = ({ teamName, teamInfos }: ITeamList) => {
         teamInfos.name,
         teamInfos.department,
         teamInfos.position,
+        teamInfos.photo,
         refreshFolders,
       );
     setFileState(false);
@@ -206,8 +207,7 @@ const WikiTeamNav = ({ teamName, teamInfos }: ITeamList) => {
   };
 
   useEffect(() => {
-    console.log(teamName);
-    console.log(teamInfos.department, teamInfos.name, teamInfos.position);
+    console.log(teamName, "위키 활성화!");
     refreshFolders();
   }, []);
 

--- a/src/components/Wiki/WikiViewer.tsx
+++ b/src/components/Wiki/WikiViewer.tsx
@@ -52,7 +52,8 @@ interface IContent {
 }
 
 const WikiViewer = ({ content }: IContent) => {
-  const { fileName, subName, date, name, position, department } = content;
+  const { fileName, subName, date, name, position, department, photo } =
+    content;
 
   const prevSubNameRef = useRef<string | null>(null);
   const prevNameRef = useRef<string | null>(null);
@@ -261,9 +262,15 @@ const WikiViewer = ({ content }: IContent) => {
           </StyledDiv>
           {name ? (
             <UserContainer>
-              <Space wrap size={16} style={{ marginRight: "14px" }}>
-                <Avatar size={38} icon={<UserOutlined />} />
-              </Space>
+              {photo ? (
+                <Space wrap size={16} style={{ marginRight: "14px" }}>
+                  <Avatar size={38} src={photo} style={{ opacity: "1" }} />
+                </Space>
+              ) : (
+                <Space wrap size={16} style={{ marginRight: "14px" }}>
+                  <Avatar size={38} icon={<UserOutlined />} />
+                </Space>
+              )}
               <div>
                 <div style={{ fontWeight: "600" }}>{name}</div>
                 <StyledSpan>

--- a/src/hooks/Wiki/api.ts
+++ b/src/hooks/Wiki/api.ts
@@ -130,6 +130,7 @@ export const addFile = async (
       name: null,
       department: null,
       position: null,
+      photo: null,
     };
 
     const order = exist.length;
@@ -156,6 +157,7 @@ export const addTeamFile = async (
   name: null | string,
   department: null | string,
   position: null | string,
+  photo: null | string,
   refreshFc: RefreshFunction,
 ): Promise<void> => {
   try {
@@ -174,6 +176,7 @@ export const addTeamFile = async (
       name: name,
       department: department,
       position: position,
+      photo: photo,
     };
 
     const order = exist.length;

--- a/src/store/wiki.ts
+++ b/src/store/wiki.ts
@@ -9,6 +9,7 @@ export interface IWikiItem {
   name: null | string;
   department: null | string;
   position: null | string;
+  photo: null | string;
 }
 
 export interface IWiki {
@@ -57,6 +58,7 @@ export const totalItems = atom<IWiki[]>({
           name: null,
           department: null,
           position: null,
+          photo: null,
         },
       ],
     },
@@ -79,6 +81,7 @@ export const totalTeamItems = atom<IWiki[]>({
           name: "",
           department: "",
           position: "",
+          photo: "",
         },
       ],
     },


### PR DESCRIPTION
## 이슈 번호

Closes #80 

## 작업 내용
임시 데이터를 제거하고 로컬스토리지 정보들을 연동했습니다.
* 이제 팀 위키에서 파일 작성시 유저의 정보가 함께 표시됩니다.

## 리뷰 요청 사항
목표했던 기능을 모두 끝내서 이제부터 리팩토링에 신경쓸 예정입니다.
혹시 버그나 이상한 부분 발견하시고 제보해주시면 최대한 남은 기한동안 수정해보겠습니다.
