### PR TITLE
Feat: 위키 하위 파일들 접기 기능 추가

### DIFF
--- a/src/components/Wiki/WikiDefaultPage.tsx
+++ b/src/components/Wiki/WikiDefaultPage.tsx
@@ -6,11 +6,8 @@ const WikiDefaultPage = () => {
     <WikiDetailHolder>
       <div>
         <object data={process.env.PUBLIC_URL + "/wiki.svg"}></object>
-        <p>왼쪽의 위키 폴더 목록을 클릭하면 상세정보가 이곳에 보여집니다.</p>
-        <p>
-          전체 위키의 FE3 WIKI 가이드를 참고하면 위키 페이지를 더욱 활용도 있게
-          사용할 수 있습니다.
-        </p>
+        <p>위키 목록을 클릭하면 파일이 이곳에 보여집니다.</p>
+        <p>전체 위키의 FE3 WIKI 가이드를 참고하세요.</p>
       </div>
     </WikiDetailHolder>
   );
@@ -31,7 +28,7 @@ const WikiDetailHolder = styled.div`
   }
   p {
     display: block;
-    margin-left: 140px;
-    text-align: start;
+    text-align: center;
+    opacity: 0.4;
   }
 `;

--- a/src/components/Wiki/WikiEditor.tsx
+++ b/src/components/Wiki/WikiEditor.tsx
@@ -123,7 +123,7 @@ const WikiEditor = () => {
       <ToastUIEditor
         ref={editorRef}
         initialValue={existSub ? existSub : INIT}
-        previewStyle="vertical"
+        previewStyle={window.innerWidth < 768 ? "tab" : "vertical"}
         height="800px"
         initialEditType="markdown"
         useCommandShortcut={false}

--- a/src/components/Wiki/WikiNav.tsx
+++ b/src/components/Wiki/WikiNav.tsx
@@ -449,10 +449,9 @@ const HideDiv = styled.div<{ $hideFolder: boolean }>`
   opacity: ${(props) => (props.$hideFolder ? "0" : "1")};
   max-height: ${(props) => (props.$hideFolder ? "0" : "auto")};
   visibility: ${(props) => (props.$hideFolder ? "hidden" : "visible")};
-  overflow: hidden;
   transition:
     max-height 0.3s,
-    opacity 1s;
+    opacity 0.3s;
     visibility 0.3s;
 `;
 

--- a/src/components/Wiki/WikiNav.tsx
+++ b/src/components/Wiki/WikiNav.tsx
@@ -20,6 +20,7 @@ import {
   TeamOutlined,
   LockOutlined,
   UnlockOutlined,
+  CaretDownOutlined,
 } from "@ant-design/icons";
 import { Input } from "antd";
 
@@ -76,10 +77,8 @@ export interface ITeamProps {
 }
 
 const WikiNav = () => {
-  // 모바일에서 메뉴 펼치고 접기를 위한 코드
   const navRef = useRef<HTMLDivElement>(null);
   const [navHeight, setNavHeight] = useState<number>();
-  const [isOpen, setIsOpen] = useState(true);
 
   const [newFolder, setNewFolder] = useState<string>("");
   const [folderName, setFolderName] = useState<string>("");
@@ -105,9 +104,9 @@ const WikiNav = () => {
   const [teamName, setTeamName] = useState<string | null>("");
   const [teamInfo, setTeamInfo] = useState<ITeamProps | null>(null);
   const setUserTeam = useSetRecoilState(userTeamName);
-
   const [userUid, setUserUid] = useState<string | null>(null);
   const [authState, setAuthState] = useState<boolean>(false);
+  const [hideFolder, setHideFolder] = useState<boolean>(false);
 
   const refreshFolders = async () => {
     const q = query(
@@ -263,13 +262,15 @@ const WikiNav = () => {
       console.log(error);
     }
   };
+
   useEffect(() => {
     setNavHeight(navRef.current?.offsetHeight);
     const handleResize = () => {
       if (window.innerWidth < 768) {
-        setIsOpen(false);
+        setHideFolder(true);
+      } else {
+        setHideFolder(false);
       }
-      console.log(isOpen);
     };
     window.addEventListener("resize", handleResize);
     return () => window.removeEventListener("resize", handleResize);
@@ -289,16 +290,25 @@ const WikiNav = () => {
     <DragDropContext onDragEnd={handleDragEnd}>
       <Droppable droppableId="folders">
         {(provided) => (
-          <Container
-            ref={navRef}
-            $isOpen={isOpen}
-            $navHeight={navHeight ?? 530}
-          >
+          <Container ref={navRef} $navHeight={navHeight ?? 530}>
             <StyledContainer>
-              <FolderWrapper>
-                <TeamOutlined />
-                <StyledFolderTitle>전체</StyledFolderTitle>
-              </FolderWrapper>
+              <div style={{ display: "flex", justifyContent: "space-between" }}>
+                <FolderWrapper>
+                  <TeamOutlined />
+                  <StyledFolderTitle>전체</StyledFolderTitle>
+                </FolderWrapper>
+                <CaretDownOutlined
+                  style={{
+                    fontSize: "9px",
+                    marginRight: "10px",
+                    cursor: "pointer",
+                  }}
+                  onClick={() => {
+                    setHideFolder((prev) => !prev);
+                  }}
+                />
+              </div>
+
               <StyledDiv>
                 <StyledForm
                   onClick={() => {
@@ -329,83 +339,86 @@ const WikiNav = () => {
                   </NewFolderContainer>
                 )}
               </StyledDiv>
-              <StyledUl {...provided.droppableProps} ref={provided.innerRef}>
-                {items.map((item, index: number) => (
-                  <Draggable
-                    key={item.title}
-                    draggableId={item.title + index}
-                    index={index}
-                  >
-                    {(provided) => (
-                      <div key={item.title + index}>
-                        <li
-                          ref={provided.innerRef}
-                          {...provided.draggableProps}
-                          {...provided.dragHandleProps}
-                          onClick={() => handleLiClick(item.title)}
-                        >
-                          <StyledTitle>
-                            <div>
-                              {(folderState && currentFolder) === item.title ? (
-                                <form onSubmit={onSubmitFolderName}>
-                                  <Input
-                                    defaultValue={item.title}
-                                    onChange={onChangeFolderName}
-                                    onClick={(e) => e.stopPropagation()}
-                                  />
-                                </form>
-                              ) : (
-                                <>
-                                  <FolderOutlined />
-                                  <StyledSpan>{item.title}</StyledSpan>
-                                </>
-                              )}
-                            </div>
-                            <div
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                handleWikiSelectToggle(e);
-                              }}
-                            >
-                              <WikiSelect title={item.title} />
-                            </div>
-                          </StyledTitle>
-                          <StyledFile
-                            className={
-                              item.title === currentFolder ? "open" : "closed"
-                            }
+              <HideDiv $hideFolder={hideFolder}>
+                <StyledUl {...provided.droppableProps} ref={provided.innerRef}>
+                  {items.map((item, index: number) => (
+                    <Draggable
+                      key={item.title}
+                      draggableId={item.title + index}
+                      index={index}
+                    >
+                      {(provided) => (
+                        <div key={item.title + index}>
+                          <li
+                            ref={provided.innerRef}
+                            {...provided.draggableProps}
+                            {...provided.dragHandleProps}
+                            onClick={() => handleLiClick(item.title)}
                           >
-                            {fileState && (
-                              <FormContainer>
-                                <FileOutlined style={{ fontSize: "14px" }} />
-                                <FileForm onSubmit={onSubmitFile}>
-                                  <Input
-                                    placeholder="새로운 파일"
-                                    onChange={onChangeFile}
-                                  />
-                                </FileForm>
-                              </FormContainer>
-                            )}
-                            {item.items &&
-                              item.items.map((v, fileIndex: number) => (
-                                <StyledItem
-                                  key={v.fileName + fileIndex}
-                                  onClick={() => handleFileClick(v.fileName)}
-                                >
-                                  <div>
-                                    <FileOutlined />
-                                    <StyledSpan>{v.fileName}</StyledSpan>
-                                  </div>
-                                </StyledItem>
-                              ))}
-                          </StyledFile>
-                        </li>
-                      </div>
-                    )}
-                  </Draggable>
-                ))}
-                {provided.placeholder}
-              </StyledUl>
+                            <StyledTitle>
+                              <div>
+                                {(folderState && currentFolder) ===
+                                item.title ? (
+                                  <form onSubmit={onSubmitFolderName}>
+                                    <Input
+                                      defaultValue={item.title}
+                                      onChange={onChangeFolderName}
+                                      onClick={(e) => e.stopPropagation()}
+                                    />
+                                  </form>
+                                ) : (
+                                  <>
+                                    <FolderOutlined />
+                                    <StyledSpan>{item.title}</StyledSpan>
+                                  </>
+                                )}
+                              </div>
+                              <div
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  handleWikiSelectToggle(e);
+                                }}
+                              >
+                                <WikiSelect title={item.title} />
+                              </div>
+                            </StyledTitle>
+                            <StyledFile
+                              className={
+                                item.title === currentFolder ? "open" : "closed"
+                              }
+                            >
+                              {fileState && (
+                                <FormContainer>
+                                  <FileOutlined style={{ fontSize: "14px" }} />
+                                  <FileForm onSubmit={onSubmitFile}>
+                                    <Input
+                                      placeholder="새로운 파일"
+                                      onChange={onChangeFile}
+                                    />
+                                  </FileForm>
+                                </FormContainer>
+                              )}
+                              {item.items &&
+                                item.items.map((v, fileIndex: number) => (
+                                  <StyledItem
+                                    key={v.fileName + fileIndex}
+                                    onClick={() => handleFileClick(v.fileName)}
+                                  >
+                                    <div>
+                                      <FileOutlined />
+                                      <StyledSpan>{v.fileName}</StyledSpan>
+                                    </div>
+                                  </StyledItem>
+                                ))}
+                            </StyledFile>
+                          </li>
+                        </div>
+                      )}
+                    </Draggable>
+                  ))}
+                  {provided.placeholder}
+                </StyledUl>
+              </HideDiv>
             </StyledContainer>
             <StyledTeamContainer>
               <FolderWrapper>
@@ -432,10 +445,20 @@ const WikiNav = () => {
 
 export default WikiNav;
 
-const Container = styled.div<{ $isOpen: boolean; $navHeight: number }>`
+const HideDiv = styled.div<{ $hideFolder: boolean }>`
+  opacity: ${(props) => (props.$hideFolder ? "0" : "1")};
+  max-height: ${(props) => (props.$hideFolder ? "0" : "auto")};
+  visibility: ${(props) => (props.$hideFolder ? "hidden" : "visible")};
+  overflow: hidden;
+  transition:
+    max-height 0.3s,
+    opacity 1s;
+    visibility 0.3s;
+`;
+
+const Container = styled.div<{ $navHeight: number }>`
   display: flex;
   flex-direction: column;
-  height: ${(props) => (props.$isOpen ? props.$navHeight : 32)};
 `;
 
 const StyledContainer = styled.div`
@@ -538,18 +561,21 @@ const StyledFile = styled.ul`
     max-height: 500px;
     div {
       opacity: 1;
+      visibility: visible;
     }
   }
   &.closed {
     max-height: 0;
     opacity: 0;
+    visibility: hidden;
   }
   overflow: hidden;
   transition:
     max-height 0.3s,
     opacity 0.3s;
+    visibility 0.3s;
   div {
-    transition: opacity 0.3s;
+    transition: opacity 0.3s, visibility 0.3s;
   }
 `;
 

--- a/src/components/Wiki/WikiSelect.tsx
+++ b/src/components/Wiki/WikiSelect.tsx
@@ -144,6 +144,9 @@ const CustomSelectMenu = styled.ul`
   padding: 0;
   margin: 0;
   margin-left: 8px;
+  @media (max-width: 768px) {
+    left: -110px;
+  }
 `;
 
 const CustomSelectItem = styled.li`

--- a/src/components/Wiki/WikiTeamNav.tsx
+++ b/src/components/Wiki/WikiTeamNav.tsx
@@ -365,7 +365,6 @@ const HideDiv = styled.div<{ $hideFolder: boolean }>`
   opacity: ${(props) => (props.$hideFolder ? "0" : "1")};
   max-height: ${(props) => (props.$hideFolder ? "0" : "auto")};
   visibility: ${(props) => (props.$hideFolder ? "hidden" : "visible")};
-  overflow: hidden;
   transition:
     max-height 0.3s,
     opacity 0.3s;

--- a/src/components/Wiki/WikiTeamNav.tsx
+++ b/src/components/Wiki/WikiTeamNav.tsx
@@ -9,6 +9,7 @@ import {
   FolderOutlined,
   FileOutlined,
   FolderAddOutlined,
+  CaretDownOutlined,
 } from "@ant-design/icons";
 import { Input } from "antd";
 
@@ -59,7 +60,9 @@ export interface TeamNewFile {
 }
 
 const WikiTeamNav = ({ teamName, teamInfos }: ITeamList) => {
+  const [hideFolder, setHideFolder] = useState<boolean>(false);
   const [inputState, setInputState] = useState<boolean>(false);
+
   const [folderName, setFolderName] = useState<string>("");
   const [newFolder, setNewFolder] = useState<string>("");
   const [newFile, setNewFile] = useState<TeamNewFile>({
@@ -203,6 +206,18 @@ const WikiTeamNav = ({ teamName, teamInfos }: ITeamList) => {
   };
 
   useEffect(() => {
+    const handleResize = () => {
+      if (window.innerWidth < 768) {
+        setHideFolder(true);
+      } else {
+        setHideFolder(false);
+      }
+    };
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  useEffect(() => {
     console.log(teamName, "위키 활성화!");
     refreshFolders();
   }, []);
@@ -215,7 +230,19 @@ const WikiTeamNav = ({ teamName, teamInfos }: ITeamList) => {
     <DragDropContext onDragEnd={handleDragEnd}>
       <Droppable droppableId="folders">
         {(provided) => (
-          <StyledContainer>
+          <StyledContainer style={{ position: "relative" }}>
+            <CaretDownOutlined
+              style={{
+                fontSize: "9px",
+                position: "absolute",
+                right: "10px",
+                top: "-25px",
+                cursor: "pointer",
+              }}
+              onClick={() => {
+                setHideFolder((prev) => !prev);
+              }}
+            />
             <StyledDiv>
               <StyledForm
                 onClick={() => {
@@ -246,83 +273,85 @@ const WikiTeamNav = ({ teamName, teamInfos }: ITeamList) => {
                 </NewFolderContainer>
               )}
             </StyledDiv>
-            <StyledUl {...provided.droppableProps} ref={provided.innerRef}>
-              {items.map((item, index: number) => (
-                <Draggable
-                  key={item.title}
-                  draggableId={item.title + index}
-                  index={index}
-                >
-                  {(provided) => (
-                    <ItemContainer key={item.title + index}>
-                      <li
-                        ref={provided.innerRef}
-                        {...provided.draggableProps}
-                        {...provided.dragHandleProps}
-                        onClick={() => handleLiClick(item.title)}
-                      >
-                        <StyledTitle>
-                          <div>
-                            {(folderState && currentFolder) === item.title ? (
-                              <form onSubmit={onSubmitFolderName}>
-                                <Input
-                                  defaultValue={item.title}
-                                  onChange={onChangeFolderName}
-                                  onClick={(e) => e.stopPropagation()}
-                                />
-                              </form>
-                            ) : (
-                              <>
-                                <FolderOutlined />
-                                <StyledSpan>{item.title}</StyledSpan>
-                              </>
-                            )}
-                          </div>
-                          <div
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              handleWikiSelectToggle(e);
-                            }}
-                          >
-                            <WikiSelect title={item.title} />
-                          </div>
-                        </StyledTitle>
-                        <StyledFile
-                          className={
-                            item.title === currentFolder ? "open" : "closed"
-                          }
+            <HideDiv $hideFolder={hideFolder}>
+              <StyledUl {...provided.droppableProps} ref={provided.innerRef}>
+                {items.map((item, index: number) => (
+                  <Draggable
+                    key={item.title}
+                    draggableId={item.title + index}
+                    index={index}
+                  >
+                    {(provided) => (
+                      <ItemContainer key={item.title + index}>
+                        <li
+                          ref={provided.innerRef}
+                          {...provided.draggableProps}
+                          {...provided.dragHandleProps}
+                          onClick={() => handleLiClick(item.title)}
                         >
-                          {fileState && (
-                            <FormContainer>
-                              <FileOutlined style={{ fontSize: "14px" }} />
-                              <FileForm onSubmit={onSubmitFile}>
-                                <Input
-                                  placeholder="새로운 파일"
-                                  onChange={onChangeFile}
-                                />
-                              </FileForm>
-                            </FormContainer>
-                          )}
-                          {item.items &&
-                            item.items.map((v, fileIndex: number) => (
-                              <StyledItem
-                                key={v.fileName + fileIndex}
-                                onClick={() => handleFileClick(v.fileName)}
-                              >
-                                <div>
-                                  <FileOutlined />
-                                  <StyledSpan>{v.fileName}</StyledSpan>
-                                </div>
-                              </StyledItem>
-                            ))}
-                        </StyledFile>
-                      </li>
-                    </ItemContainer>
-                  )}
-                </Draggable>
-              ))}
-              {provided.placeholder}
-            </StyledUl>
+                          <StyledTitle>
+                            <div>
+                              {(folderState && currentFolder) === item.title ? (
+                                <form onSubmit={onSubmitFolderName}>
+                                  <Input
+                                    defaultValue={item.title}
+                                    onChange={onChangeFolderName}
+                                    onClick={(e) => e.stopPropagation()}
+                                  />
+                                </form>
+                              ) : (
+                                <>
+                                  <FolderOutlined />
+                                  <StyledSpan>{item.title}</StyledSpan>
+                                </>
+                              )}
+                            </div>
+                            <div
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleWikiSelectToggle(e);
+                              }}
+                            >
+                              <WikiSelect title={item.title} />
+                            </div>
+                          </StyledTitle>
+                          <StyledFile
+                            className={
+                              item.title === currentFolder ? "open" : "closed"
+                            }
+                          >
+                            {fileState && (
+                              <FormContainer>
+                                <FileOutlined style={{ fontSize: "14px" }} />
+                                <FileForm onSubmit={onSubmitFile}>
+                                  <Input
+                                    placeholder="새로운 파일"
+                                    onChange={onChangeFile}
+                                  />
+                                </FileForm>
+                              </FormContainer>
+                            )}
+                            {item.items &&
+                              item.items.map((v, fileIndex: number) => (
+                                <StyledItem
+                                  key={v.fileName + fileIndex}
+                                  onClick={() => handleFileClick(v.fileName)}
+                                >
+                                  <div>
+                                    <FileOutlined />
+                                    <StyledSpan>{v.fileName}</StyledSpan>
+                                  </div>
+                                </StyledItem>
+                              ))}
+                          </StyledFile>
+                        </li>
+                      </ItemContainer>
+                    )}
+                  </Draggable>
+                ))}
+                {provided.placeholder}
+              </StyledUl>
+            </HideDiv>
           </StyledContainer>
         )}
       </Droppable>
@@ -332,7 +361,19 @@ const WikiTeamNav = ({ teamName, teamInfos }: ITeamList) => {
 
 export default WikiTeamNav;
 
+const HideDiv = styled.div<{ $hideFolder: boolean }>`
+  opacity: ${(props) => (props.$hideFolder ? "0" : "1")};
+  max-height: ${(props) => (props.$hideFolder ? "0" : "auto")};
+  visibility: ${(props) => (props.$hideFolder ? "hidden" : "visible")};
+  overflow: hidden;
+  transition:
+    max-height 0.3s,
+    opacity 0.3s;
+    visibility 0.3s;
+`;
+
 const StyledContainer = styled.div`
+  position: "relative";
   margin: 0;
   margin-top: -15px;
   padding: 0;
@@ -414,18 +455,21 @@ const StyledFile = styled.ul`
     max-height: 500px;
     div {
       opacity: 1;
+      visibility: visible;
     }
   }
   &.closed {
     max-height: 0;
     opacity: 0;
+    visibility: hidden;
   }
   overflow: hidden;
   transition:
     max-height 0.3s,
     opacity 0.3s;
+    visibility 0.3s;
   div {
-    transition: opacity 0.3s;
+    transition: opacity 0.3s, visibility 0.3s;
   }
 `;
 

--- a/src/components/Wiki/WikiViewer.tsx
+++ b/src/components/Wiki/WikiViewer.tsx
@@ -335,6 +335,7 @@ const StyledDiv = styled.div`
   @media (max-width: 768px) {
     flex-direction: column;
     align-items: flex-start;
+    margin-bottom: 20px;
   }
 `;
 const StyledViewer = styled.div`


### PR DESCRIPTION
## 이슈 번호

Closes #101 

## 작업 내용
전체 위키, 팀 위키 모두 접기와 펼치기 사용이 가능합니다.
반응형 사이즈(768) 이하 사이즈로 가면 자동으로 위키가 접혀집니다.

## 리뷰 요청 사항
